### PR TITLE
feat(editor): display line/column number in editor

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -29,9 +29,10 @@
     <script src="scripts/bower_components/jquery-ui/jquery-ui.js"></script>
     <script src="scripts/bower_components/angular/angular.js"></script>
     <script src="scripts/bower_components/gridster/dist/jquery.gridster.with-extras.js"></script>
-    <script src="scripts/bower_components/requirejs/require.js"></script>
     <script src="scripts/bower_components/medium-editor/dist/js/medium-editor.js"></script>
     <script src="scripts/bower_components/ment.io/dist/mentio.js"></script>
+    
+    <script src="scripts/bower_components/requirejs/require.js"></script>
     <!-- endbuild -->
 
     <!-- build:js scripts/superdesk-core.js -->

--- a/app/scripts/superdesk-authoring/authoring.js
+++ b/app/scripts/superdesk-authoring/authoring.js
@@ -645,7 +645,7 @@
                 };
 
                 function applyTheme() {
-                    elem.closest('#theme-container').attr('class', scope.theme.cssClass);
+                    elem.closest('#theme-container').attr('class', scope.theme && scope.theme.cssClass);
                 }
             }
         };

--- a/app/scripts/superdesk-authoring/styles/article-edit.less
+++ b/app/scripts/superdesk-authoring/styles/article-edit.less
@@ -449,3 +449,6 @@
 
 // }
 
+.text-editor-info {
+	font-size: 89%;
+}

--- a/app/scripts/superdesk-authoring/views/authoring.html
+++ b/app/scripts/superdesk-authoring/views/authoring.html
@@ -52,11 +52,12 @@
                                 <textarea class="abstract" maxlength="{{abstractHardLimit}}" sd-auto-height ng-model="item.abstract" ng-if="_editable"></textarea>
 			                	<div class="abstract" ng-if="!_editable">{{item.abstract}}</div>
                 			</div>
-                			<div class="field">
+                			<div class="field" ng-init="cursor={}">
                 				<label translate>Body</label>
                                 <span sd-word-count data-item="item.body_html" data-html="true"></span>
-                				<div sd-text-editor class="text-editor" ng-model="item.body_html" ng-if="_editable"></div>
+                				<pre sd-text-editor class="text-editor" ng-model="item.body_html" ng-if="_editable" data-cursor="cursor"></pre>
 		                    	<div class="text-editor" sd-html-preview="item.body_html" ng-if="!_editable"></div>
+                                <code class="text-editor-info" ng-if="_editable && cursor.line"><small translate>Line: {{ cursor.line }}, Column: {{ cursor.column }}</small></code>
                 			</div>
                 		</fieldset>
 		            </form>

--- a/app/scripts/superdesk/editor/editor.js
+++ b/app/scripts/superdesk/editor/editor.js
@@ -3,22 +3,61 @@
 
 angular.module('superdesk.editor', [])
     .directive('sdTextEditor', function() {
+
+        var TEXT_TYPE = 3;
+
         var config = {
             buttons: ['bold', 'italic', 'underline', 'quote', 'anchor']
         };
 
+        /**
+         * Get number of lines for all p nodes before given node withing same parent.
+         */
+        function getLinesBeforeNode(node) {
+            var lines = 0;
+            var p = node.previousSibling;
+            while (p) {
+                if (p.childNodes[0].nodeType === TEXT_TYPE) {
+                    lines += p.childNodes[0].wholeText.split('\n').length;
+                } else {
+                    lines += 1; // empty paragraph
+                }
+                p = p.previousSibling;
+            }
+
+            return lines;
+        }
+
+        /**
+         * Get line/column coordinates for given cursor position.
+         */
+        function getLineColumn() {
+            var text, lines, linesBefore;
+            var selection = window.getSelection();
+            if (selection.anchorNode.nodeType === TEXT_TYPE) {
+                text = selection.anchorNode.wholeText.substring(0, selection.anchorOffset);
+                lines = text.split('\n');
+                linesBefore = getLinesBeforeNode(selection.anchorNode.parentNode);
+            } else {
+                text = '';
+                lines = [text];
+                linesBefore = getLinesBeforeNode(selection.anchorNode);
+            }
+            return {
+                line: lines.length + linesBefore,
+                column: lines[lines.length - 1].length + 1
+            };
+        }
+
         return {
+            scope: {cursor: '='},
             require: 'ngModel',
             link: function(scope, elem, attrs, ngModel) {
-
                 function updateModel() {
                     scope.$apply(function editorModelUpdate() {
                         ngModel.$setViewValue(elem.html());
                     });
                 }
-
-                elem.on('input', updateModel);
-                elem.on('blur', updateModel);
 
                 ngModel.$render = function() {
                     elem.empty();
@@ -26,9 +65,16 @@ angular.module('superdesk.editor', [])
                     this.editor = new window.MediumEditor(elem, config);
                 };
 
+                elem.on('input', updateModel);
+                elem.on('blur', updateModel);
+                elem.on('keydown keyup click', function() {
+                    scope.$apply(function() {
+                        angular.extend(scope.cursor, getLineColumn());
+                    });
+                });
+
                 scope.$on('$destroy', function() {
-                    elem.off('input');
-                    elem.off('blur');
+                    elem.off();
                 });
             }
         };

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     "ng-file-upload": "1.6.12",
     "raven-js": "1.1.11",
     "jquery-ui": "1.11.2",
-    "medium-editor": "1.9.4",
+    "medium-editor": "2.0.0",
     "ment.io": "0.9.14"
   },
   "resolutions": {


### PR DESCRIPTION
using selection to find node and offset where the cursor is and then counting manually.
it can only work with preformatted text, so switched editor to use `<pre>` tags.
@nidzix can use some style, but not sure where it should be displayed..