### PR TITLE
[SD-1237] Content items display either the desk or the workspace

### DIFF
--- a/app/scripts/superdesk-archive/views/media-box-grid.html
+++ b/app/scripts/superdesk-archive/views/media-box-grid.html
@@ -9,7 +9,7 @@
 
 <div sd-item-rendition data-item="item" data-rendition="thumbnail"></div>
 
-<div class="media"  ng-show="item.type == 'text' || item.type == 'composite'">
+<div class="media"  ng-show="item.type == 'text' || item.type == 'composite' || item.type == 'preformatted'">
     <small title="{{ item.headline }}">{{ item.headline }}</small>
     <span sd-item-container data-item="item" class="container"></span>
 </div>

--- a/app/scripts/superdesk-items-common/styles/media-archive.less
+++ b/app/scripts/superdesk-items-common/styles/media-archive.less
@@ -262,7 +262,7 @@
 		&.media-picture {
 			
 		}
-		&.media-text,&.media-composite {
+		&.media-text,&.media-preformatted,&.media-composite {
 			.media {
 				max-width: @sfbox_minWidth;
 				font-size: 12px;

--- a/app/scripts/superdesk-search/search.js
+++ b/app/scripts/superdesk-search/search.js
@@ -572,18 +572,14 @@
                 template: '{{item.container}}',
                 link: function(scope, elem) {
 
-                    if (!scope.item.task) {
-                        return;
-                    }
-
-                    if (scope.item.task.desk) {
-                        desks.initialize().then(function() {
-                            scope.item.container = 'desk:' + desks.deskLookup[scope.item.task.desk].name ;
-                        });
-                    } else if (scope.item.task.user) {
-                        scope.item.container = 'location:workspace';
-                    } else {
-                        scope.item.container = 'location:unkown';
+                    if (scope.item._type !== 'ingest') {
+                        if (scope.item.task && scope.item.task.desk) {
+                            desks.initialize().then(function() {
+                                scope.item.container = 'desk:' + desks.deskLookup[scope.item.task.desk].name ;
+                            });
+                        } else {
+                            scope.item.container = 'location:workspace';
+                        }
                     }
                 }
             };


### PR DESCRIPTION
* Refactored the location directive to display the location information only for archive repo
* If content items are on a desk then the desk name is splayed
* If content item is not on a desk then we display location:workspace

I included a fix for the "preformatted" content type in the grid view.