### PR TITLE
(fix)[Login] Fixing the error handling in case of incorrect credentials. 

### DIFF
--- a/app/scripts/superdesk/auth/auth-interceptor.js
+++ b/app/scripts/superdesk/auth/auth-interceptor.js
@@ -1,4 +1,4 @@
-define([], function() {
+define(['lodash'], function(_) {
     'use strict';
 
     /**
@@ -26,8 +26,12 @@ define([], function() {
                 return response;
             },
             responseError: function(response) {
+
                 if (response.status === 401) {
-                    return handleAuthExpired(response);
+
+                    if (!(((response.data || {})._issues || {}).credentials)) {
+                        return handleAuthExpired(response);
+                    }
                 }
 
                 return $q.reject(response);

--- a/app/scripts/superdesk/auth/auth-interceptor_spec.js
+++ b/app/scripts/superdesk/auth/auth-interceptor_spec.js
@@ -21,12 +21,35 @@ define([
             spyOn(session, 'getIdentity').and.returnValue($q.when());
             spyOn(request, 'resend');
 
-            interceptor.response(response);
+            interceptor.responseError(response);
             $rootScope.$digest();
 
             expect(session.expire).toHaveBeenCalled();
             expect(request.resend).toHaveBeenCalled();
         }));
 
+        it('should intercept 401 response and reject the request if payload has credentials 1',
+        inject(function($injector, $q, $rootScope, session, request) {
+
+            var interceptor = $injector.invoke(AuthInterceptor),
+                config = {method: 'POST', url: 'auth', headers: {}},
+                response = {status: 401, config: config, data: {_issues: {credentials: 1}}};
+
+            spyOn(session, 'expire');
+            spyOn(session, 'getIdentity').and.returnValue($q.when());
+            spyOn(request, 'resend');
+
+            var result;
+            interceptor.responseError(response).then(function(success) {
+                result = success;
+            }, function(rejection) {
+                result = rejection;
+            });
+
+            $rootScope.$digest();
+            expect(result.data._issues.credentials).toBe(1);
+            expect(session.expire).not.toHaveBeenCalled();
+            expect(request.resend).not.toHaveBeenCalled();
+        }));
     });
 });

--- a/app/scripts/superdesk/auth/login-modal-directive.js
+++ b/app/scripts/superdesk/auth/login-modal-directive.js
@@ -23,7 +23,7 @@ define([], function() {
                         }, function(rejection) {
                             scope.isLoading = false;
                             scope.loginError = rejection.status;
-                            if (scope.loginError === 400) {
+                            if (scope.loginError === 401) {
                                 scope.password = null;
                             }
                         });

--- a/app/scripts/superdesk/auth/login-modal.html
+++ b/app/scripts/superdesk/auth/login-modal.html
@@ -1,6 +1,5 @@
 <div class="login-screen" ng-show="active">
     <div class="login-form-container">
-
         <p ng-if="identity._id" class="session-error">{{ 'Your session has expired.'|translate }}<br />{{ 'Please log in again.'|translate }}</p>
 
         <div class="logo-handler" ng-show="!identity.Avatar">
@@ -27,7 +26,7 @@
             </form>            
 
             <div class="error-handler" ng-switch on="loginError">
-                <p class="error" ng-switch-when="400" translate>Oops! Invalid Username or Password.<br />Please try again.</p>
+                <p class="error" ng-switch-when="401" translate>Oops! Invalid Username or Password.<br />Please try again.</p>
                 <p class="error" ng-switch-when="403" translate>Sorry, but your account has been suspended.</p>
                 <p class="error" ng-show="loginError" ng-switch-default translate>Sorry, but can't reach the server now.<br />Please try again later.</p>
 


### PR DESCRIPTION
Due to recent changes to the error handling on the server side, API is returning 401 in case of incorrect credentials. The 401 is intercepted and error callback is not invoked (due to SD-273). Hence the login button is not enabled and there is no feedback to the user about login failure. The change password (SD-603) also has the same problem.

Hence made this change in the interceptor to invoke error callback in case of wrong credentials using payload.

### Alternate solution:
Change the API to return 403 or 400 (as used previously) and remove the check from the interceptor. Only return 401 in case of token authentication failure.

Please review let me know your thoughts on this.