### PR TITLE
Prevent sending too many "username unique" queries to server.

### DIFF
--- a/app/scripts/superdesk-users/views/edit-form.html
+++ b/app/scripts/superdesk-users/views/edit-form.html
@@ -48,6 +48,9 @@
                   <label for="username" translate>username</label>
                   <input type="text" name="username" id="username"
                     ng-model="user.username"
+                    ng-model-options="{
+                        updateOn: 'default blur',
+                        debounce: {'default': 500, 'blur': 0} }"
                     ng-readonly="user._id"
                     ng-pattern="usernamePattern"
                     sd-user-unique data-unique-field="username" data-exclude="user"


### PR DESCRIPTION
A delay is added to the corresponding form field's model change
so that request is fired only after the user has (presumably) stopped
typing. In case of a 'blur' event, an API query is fired immediately.

Fixes #810